### PR TITLE
update cuda version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.2.0-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.2.2-cudnn8-runtime-ubuntu20.04
 
 RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     # Install python 3.8, and other tools if needed.


### PR DESCRIPTION
I noticed that the docker wasn't building. The version of cuda is no longer good.
It seems that we need to switch from: nvidia/cuda:11.2.0-cudnn8-runtime-ubuntu20.04 to nvidia/cuda:11.2.1-cudnn8-runtime-ubuntu20.04.